### PR TITLE
Limits flex-basis for IE10/11

### DIFF
--- a/lib/lost-column.js
+++ b/lib/lost-column.js
@@ -154,6 +154,14 @@ module.exports = function lostColumnDecl(css, settings, result) {
           value: lgLogic.calcValue(lostColumn, lostColumnGutter, lostColumnRounder, unit)
         });
 
+        // IE 10-11 don't take into account box-sizing when calculating flex-basis, but
+        // adding an explicit max-width keeps them in line.
+        // https://github.com/philipwalton/flexbugs#7-flex-basis-doesnt-account-for-box-sizingborder-box
+        decl.cloneBefore({
+          prop: 'max-width',
+          value: lgLogic.calcValue(lostColumn, lostColumnGutter, lostColumnRounder, unit)
+        });
+
         if (gridDirection === 'rtl') {
           newBlock(
             decl,

--- a/test/lost-at-rule.js
+++ b/test/lost-at-rule.js
@@ -42,6 +42,7 @@ describe('lost-at-rule', function() {
       '  flex-grow: 0;\n' +
       '  flex-shrink: 0;\n' +
       '  flex-basis: calc(99.9% * 1/3 - (30px - 30px * 1/3));\n' +
+      '  max-width: calc(99.9% * 1/3 - (30px - 30px * 1/3));\n' +
       '  width: calc(99.9% * 1/3 - (30px - 30px * 1/3));\n' +
       '}\n' +
       'div:nth-child(1n) {\n' +

--- a/test/lost-column.js
+++ b/test/lost-column.js
@@ -52,6 +52,7 @@ describe('lost-column', function() {
       'a { lost-column: 2/6 3 60px flex; }',
       'a { flex-grow: 0; flex-shrink: 0; ' +
       'flex-basis: calc(99.9% * 2/6 - (60px - 60px * 2/6)); ' +
+      'max-width: calc(99.9% * 2/6 - (60px - 60px * 2/6)); ' +
       'width: calc(99.9% * 2/6 - (60px - 60px * 2/6)); }\n' +
       'a:nth-child(1n) { margin-right: 60px; margin-left: 0; }\n' +
       'a:last-child { margin-right: 0; }\n' +


### PR DESCRIPTION
Fix for IE10/11 not taking box-sizing into account when using flex-basis. Adding a max-width of the same value keeps IE from growing the element too large.